### PR TITLE
Github api connection error

### DIFF
--- a/app/initialize.js
+++ b/app/initialize.js
@@ -102,20 +102,20 @@ document.addEventListener('DOMContentLoaded', function init() {
   axios.get('//api.github.com/orgs/nio-blocks/repos?per_page=100')
   .then(function(response) {
     var data = response.data;
+    // response.headers.link does not exist with fewer than 100 blocks
     if (response.headers.link) {
-      // 12/7/16 - response.headers.link does not exist with fewer than 100
-      // blocks. Check again when we have more than 100 blocks.
-      // Only then is paging necessary -- KD
       var link_header = parse_link_header(response.headers.link);
       axios.get(link_header.next)
       .then(function(nextResponse) {
         var newData = nextResponse.data;
         link_header = parse_link_header(nextResponse.headers.link);
         data = data.concat(newData);
-        return renderTable(data);
+        renderTable(data);
       });
     }
-    renderTable(data);
+    else {
+      renderTable(data);
+    }
   })
   .catch(function(response) {
     console.log('error connecting to github api');

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -102,18 +102,20 @@ document.addEventListener('DOMContentLoaded', function init() {
   axios.get('//api.github.com/orgs/nio-blocks/repos?per_page=100')
   .then(function(response) {
     var data = response.data;
-    var link_header = parse_link_header(response.headers.link);
-    if (link_header.next) {
+    if (response.headers.link) {
+      // 12/7/16 - response.headers.link does not exist
+      // check this again when we have more than 100 blocks
+      // only then is paging necessary -- KD
+      var link_header = parse_link_header(response.headers.link);
       axios.get(link_header.next)
       .then(function(nextResponse) {
         var newData = nextResponse.data;
         link_header = parse_link_header(nextResponse.headers.link);
         data = data.concat(newData);
-        renderTable(data);
+        return renderTable(data);
       });
-    } else {
-      renderTable(data);
     }
+    renderTable(data);
   })
   .catch(function(response) {
     console.log('error connecting to github api');

--- a/app/initialize.js
+++ b/app/initialize.js
@@ -103,9 +103,9 @@ document.addEventListener('DOMContentLoaded', function init() {
   .then(function(response) {
     var data = response.data;
     if (response.headers.link) {
-      // 12/7/16 - response.headers.link does not exist
-      // check this again when we have more than 100 blocks
-      // only then is paging necessary -- KD
+      // 12/7/16 - response.headers.link does not exist with fewer than 100
+      // blocks. Check again when we have more than 100 blocks.
+      // Only then is paging necessary -- KD
       var link_header = parse_link_header(response.headers.link);
       axios.get(link_header.next)
       .then(function(nextResponse) {


### PR DESCRIPTION
It appears the github api doesn't send `headers.link` back unless the `response.data` max of 100 is hit. We don't have more than 100 blocks, so we can't test this right now, but the site now loads correctly.